### PR TITLE
Fix resolving cities

### DIFF
--- a/src/components/CurrentCityWeather/CurrentCityWeather.js
+++ b/src/components/CurrentCityWeather/CurrentCityWeather.js
@@ -7,14 +7,16 @@ import { Col, Row } from "react-bootstrap";
 const CurrentCityWeather = () => {
   const [error, setError] = useState(null);
   const [isLoaded, setIsLoaded] = useState(false);
-  const [city, setCity] = useState("New York City");
+  const [cityCoordinates, setCityCoordinates] = useState({lat: '40.7128', lon: '-74.0060'});
   const [results, setResults] = useState(null);
 
   
   useEffect(() => {
     fetch(
-      "https://api.openweathermap.org/data/2.5/weather?q=" +
-        city +
+      "https://api.openweathermap.org/data/2.5/weather?lat=" +
+        cityCoordinates.lat +
+        "&lon=" +
+        cityCoordinates.lon +
         "&units=metric" +
         "&appid=" +
         process.env.REACT_APP_APIKEY
@@ -40,7 +42,14 @@ const CurrentCityWeather = () => {
       .catch((err) => {
         setError(err);
       });
-  }, [city]);
+  }, [cityCoordinates]);
+
+  function setCoordinates(place) {
+    var latitude = place.geometry.location.lat();
+    var longitude = place.geometry.location.lng();
+    var coordinates = {lat: latitude, lon: longitude};
+    setCityCoordinates(coordinates);
+  }
 
   return (
     <>
@@ -49,9 +58,9 @@ const CurrentCityWeather = () => {
         <Autocomplete
           apiKey={process.env.REACT_APP_GOOGLE_MAPS_API_KEY}
           onPlaceSelected={(place) => {
-            setCity(place.formatted_address)
+            setCoordinates(place);
           }}
-          defaultValue={city}
+          defaultValue={"New York, NY, USA"}
           className="inputCity"
         />
         {error && (
@@ -59,7 +68,7 @@ const CurrentCityWeather = () => {
             <h2 className="px-3">Error: {error.message}</h2>
           </div>
         )}
-        {city && !error && !isLoaded && (
+        {cityCoordinates && !error && !isLoaded && (
           <div className="WeatherResultsLoading">
             <h2 className="px-3">Loading...</h2>
           </div>

--- a/src/components/CurrentCityWeather/CurrentCityWeather.js
+++ b/src/components/CurrentCityWeather/CurrentCityWeather.js
@@ -9,6 +9,7 @@ const CurrentCityWeather = () => {
   const [isLoaded, setIsLoaded] = useState(false);
   const [cityCoordinates, setCityCoordinates] = useState({lat: '40.7128', lon: '-74.0060'});
   const [results, setResults] = useState(null);
+  const [city, setCity] = useState('New York');
 
   
   useEffect(() => {
@@ -51,6 +52,11 @@ const CurrentCityWeather = () => {
     setCityCoordinates(coordinates);
   }
 
+  function getCity(address) {
+    var addressComponents = address.split(",");
+    setCity(addressComponents[0]);
+  }
+
   return (
     <>
       <div className="CurrentCityWeather">
@@ -59,6 +65,7 @@ const CurrentCityWeather = () => {
           apiKey={process.env.REACT_APP_GOOGLE_MAPS_API_KEY}
           onPlaceSelected={(place) => {
             setCoordinates(place);
+            getCity(place.formatted_address);
           }}
           defaultValue={"New York, NY, USA"}
           className="inputCity"
@@ -90,7 +97,7 @@ const CurrentCityWeather = () => {
                   </div>
                   <i>
                     <div>
-                      {results.name}, {results.sys.country}
+                      {city}, {results.sys.country}
                     </div>
                   </i>
                 </Col>


### PR DESCRIPTION
- Changed how forecasts are fetched. Instead of fetching by city name, now fetching by longitude and latitude.
- Changed how we get the city to display, because fetching by coordinates sometimes returns the forecast for a neighbouring city in case of small cities or cities that are very close to each other.

Closes #21 