### PR TITLE
Replace case error.UNKNOW_ERROR with case default.

### DIFF
--- a/src/components/CurrentCityWeather/CurrentCityWeather.js
+++ b/src/components/CurrentCityWeather/CurrentCityWeather.js
@@ -45,7 +45,7 @@ const CurrentCityWeather = () => {
         case error.TIMEOUT:
           alert("The request to get user location timed out.")
           break;
-        case error.UNKNOWN_ERROR:
+        default:
           alert("An unknown error occurred.")
           break;
     }


### PR DESCRIPTION
error.UNKNOWN_ERROR error type of GeolocationPositionError.code does not exist.
[documentation](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError/code)
error.UUNKNOWN_ERROR defaults to undefined which is of a different type from  GeolocationPositionError.code which is an unsigned short.
comparing both could lead to future bugs and is replaced with a default case to avoid any such possible future bugs.

fixes #36 

## Please, go through these steps before you submit a PR.
- [x] My Pod Leader knows I'm working on this Pull Request
- [x] I've explained what the Pull Request is adding.
- [x] I've explained why this is important.
